### PR TITLE
CCTRI-1654 - Manage authentication errors in Chronicle:

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ header set to `Bearer <JWT>`.
   "project_id": "<PROJECT_ID>",
   "private_key_id": "<PRIVATE_KEY_ID>",
   "private_key": "<PRIVATE_KEY>",
+  "client_email": "<CLIENT_EMAIL>",
   "client_id": "<CLIENT_ID>",
   "auth_uri": "<AUTH_URI>",
   "token_uri": "<TOKEN_URI>",

--- a/api/errors.py
+++ b/api/errors.py
@@ -6,6 +6,7 @@ INVALID_ARGUMENT = 'invalid argument'
 PERMISSION_DENIED = 'permission denied'
 UNKNOWN = 'unknown'
 TOO_MANY_REQUESTS = 'too many requests'
+AUTH_ERROR = 'authorization error'
 
 
 class TRFormattedError(Exception):
@@ -60,11 +61,11 @@ class UnexpectedChronicleResponseError(TRFormattedError):
             super().__init__(status, f"{title}: {message}")
 
 
-class InvalidJWTError(TRFormattedError):
-    def __init__(self):
+class AuthorizationError(TRFormattedError):
+    def __init__(self, message):
         super().__init__(
-            PERMISSION_DENIED,
-            'Invalid Authorization Bearer JWT.'
+            AUTH_ERROR,
+            f'Authorization failed: {message}'
         )
 
 

--- a/api/errors.py
+++ b/api/errors.py
@@ -69,14 +69,6 @@ class AuthorizationError(TRFormattedError):
         )
 
 
-class InvalidChronicleCredentialsError(TRFormattedError):
-    def __init__(self, error):
-        super().__init__(
-            PERMISSION_DENIED,
-            f'Google Chronicle Authorization failed: {str(error)}.'
-        )
-
-
 class InvalidArgumentError(TRFormattedError):
     def __init__(self, error):
         super().__init__(

--- a/api/utils.py
+++ b/api/utils.py
@@ -11,7 +11,9 @@ from api.errors import (
 
 
 def get_auth_token() -> [str, Exception]:
-    """Parse the incoming request's Authorization header and Validate it."""
+    """
+    Parse and validate incoming request Authorization header.
+    """
     expected_errors = {
         KeyError: 'Authorization header is missing',
         AssertionError: 'Wrong authorization type'
@@ -26,8 +28,7 @@ def get_auth_token() -> [str, Exception]:
 
 def get_jwt() -> [dict, Exception]:
     """
-    Get Authorization token and validate its signature
-    according the application's secret key .
+    Decode Authorization token. Extract and validate credentials.
     """
     jwt_payload_keys = (
         'type',

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,5 @@
 from authlib.jose import jwt
-from authlib.jose.errors import JoseError, BadSignatureError, DecodeError
+from authlib.jose.errors import BadSignatureError, DecodeError
 from flask import request, current_app, jsonify, g
 from google.oauth2 import service_account
 from googleapiclient import _auth

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ class Config(object):
 
     AUTH_SCOPES = ['https://www.googleapis.com/auth/chronicle-backstory']
 
-    SECRET_KEY = os.environ.get('SECRET_KEY', '')
+    SECRET_KEY = os.environ.get('SECRET_KEY', None)
 
     CTR_ENTITIES_DEFAULT_LIMIT = 100
     CTR_ENTITIES_LIMIT = CTR_ENTITIES_DEFAULT_LIMIT

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -31,7 +31,7 @@ def test_enrich_call_with_authorization_header_failure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'authorization_header_failure'
+        'Authorization header is missing'
     )
 
 
@@ -44,7 +44,7 @@ def test_enrich_call_with_wrong_authorization_type(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_authorization_type'
+        'Wrong authorization type'
     )
 
 
@@ -56,7 +56,7 @@ def test_enrich_call_with_wrong_jwt_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_structure'
+        'Wrong JWT structure'
     )
 
 
@@ -68,7 +68,7 @@ def test_enrich_call_with_jwt_encoded_by_wrong_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'jwt_encoded_by_wrong_key'
+        'Failed to decode JWT with provided key'
     )
 
 
@@ -81,7 +81,7 @@ def test_enrich_call_with_wrong_jwt_payload_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_payload_structure'
+        'Wrong JWT payload structure'
     )
 
 
@@ -96,7 +96,7 @@ def test_enrich_call_with_missed_secret_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'missed_secret_key'
+        '<SECRET_KEY> is missing'
     )
 
 

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -24,12 +24,12 @@ def invalid_json():
 
 
 def test_enrich_call_without_jwt_failure(
-        route, client, invalid_jwt_expected_payload
+        route, client, authorization_is_missing_expected_payload
 ):
     response = client.post(route)
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_is_missing_expected_payload
 
 
 def test_enrich_call_with_invalid_jwt_failure(
@@ -48,7 +48,6 @@ def test_enrich_call_with_valid_jwt_but_invalid_json_failure(
     with patch('api.utils._auth.authorized_http'), \
          patch('api.utils.service_account.'
                'Credentials.from_service_account_info'):
-
         response = client.post(route,
                                headers=headers(valid_jwt),
                                json=invalid_json)
@@ -67,10 +66,9 @@ def test_enrich_call_with_unauthorized_creds_failure(
         chronicle_response_unauthorized_creds,
         unauthorized_creds_expected_payload
 ):
-
     with patch('api.utils._auth.authorized_http') as authorized_http_mock, \
-         patch('api.utils.service_account.'
-               'Credentials.from_service_account_info'):
+            patch('api.utils.service_account.'
+                  'Credentials.from_service_account_info'):
         authorized_http_mock.return_value = ClientMock(
             chronicle_response_unauthorized_creds
         )
@@ -173,8 +171,8 @@ def test_enrich_call_success_with_extended_error_handling(
         success_enrich_body, unauthorized_creds_body
 ):
     with patch('api.utils._auth.authorized_http') as authorized_http_mock, \
-         patch('api.utils.service_account.'
-               'Credentials.from_service_account_info'):
+            patch('api.utils.service_account.'
+                  'Credentials.from_service_account_info'):
         authorized_http_mock.return_value = ClientMock(
             side_effect=[
                 chronicle_response_ok,

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -67,8 +67,8 @@ def test_enrich_call_with_unauthorized_creds_failure(
         unauthorized_creds_expected_payload
 ):
     with patch('api.utils._auth.authorized_http') as authorized_http_mock, \
-            patch('api.utils.service_account.'
-                  'Credentials.from_service_account_info'):
+        patch('api.utils.service_account.'
+              'Credentials.from_service_account_info'):
         authorized_http_mock.return_value = ClientMock(
             chronicle_response_unauthorized_creds
         )

--- a/tests/unit/api/test_enrich.py
+++ b/tests/unit/api/test_enrich.py
@@ -120,8 +120,8 @@ def test_enrich_call_with_bad_request_success(
         bad_request_expected_payload
 ):
     with patch('api.utils._auth.authorized_http') as authorized_http_mock, \
-            patch('api.utils.service_account.'
-                  'Credentials.from_service_account_info'):
+        patch('api.utils.service_account.'
+              'Credentials.from_service_account_info'):
         authorized_http_mock.return_value = ClientMock(
             chronicle_response_bad_request
         )
@@ -171,8 +171,8 @@ def test_enrich_call_success_with_extended_error_handling(
         success_enrich_body, unauthorized_creds_body
 ):
     with patch('api.utils._auth.authorized_http') as authorized_http_mock, \
-            patch('api.utils.service_account.'
-                  'Credentials.from_service_account_info'):
+        patch('api.utils.service_account.'
+              'Credentials.from_service_account_info'):
         authorized_http_mock.return_value = ClientMock(
             side_effect=[
                 chronicle_response_ok,

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -24,7 +24,7 @@ def test_health_call_with_authorization_header_failure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'authorization_header_failure'
+        'Authorization header is missing'
     )
 
 
@@ -38,7 +38,7 @@ def test_health_call_with_wrong_authorization_type(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_authorization_type'
+        'Wrong authorization type'
     )
 
 
@@ -50,7 +50,7 @@ def test_health_call_with_wrong_jwt_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_structure'
+        'Wrong JWT structure'
     )
 
 
@@ -62,7 +62,7 @@ def test_health_call_with_jwt_encoded_by_wrong_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'jwt_encoded_by_wrong_key'
+        'Failed to decode JWT with provided key'
     )
 
 
@@ -75,7 +75,7 @@ def test_health_call_with_wrong_jwt_payload_structure(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'wrong_jwt_payload_structure'
+        'Wrong JWT payload structure'
     )
 
 
@@ -90,7 +90,7 @@ def test_health_call_with_missed_secret_key(
 
     assert response.status_code == HTTPStatus.OK
     assert response.json == authorization_errors_expected_payload(
-        'missed_secret_key'
+        '<SECRET_KEY> is missing'
     )
 
 
@@ -100,12 +100,12 @@ def test_health_call_with_invalid_creds_failure(
 ):
     with patch('api.utils.service_account.'
                'Credentials.from_service_account_info',
-               side_effect=ValueError("Wrong structure")):
+               side_effect=ValueError("Wrong credentials")):
         response = client.post(route, headers=headers(valid_jwt))
 
         assert response.status_code == HTTPStatus.OK
         assert response.json == authorization_errors_expected_payload(
-            'invalid_creds_failure'
+            'Wrong credentials'
         )
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -17,12 +17,12 @@ def route(request):
 
 
 def test_health_call_without_jwt_failure(
-        route, client, invalid_jwt_expected_payload
+        route, client, authorization_is_missing_expected_payload
 ):
     response = client.post(route)
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_is_missing_expected_payload
 
 
 def test_health_call_with_invalid_jwt_failure(

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -16,22 +16,97 @@ def route(request):
     return request.param
 
 
-def test_health_call_without_jwt_failure(
-        route, client, authorization_is_missing_expected_payload
+def test_health_call_with_authorization_header_failure(
+        route, client,
+        authorization_errors_expected_payload
 ):
     response = client.post(route)
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == authorization_is_missing_expected_payload
+    assert response.json == authorization_errors_expected_payload(
+        'authorization_header_failure'
+    )
 
 
-def test_health_call_with_invalid_jwt_failure(
-        route, client, invalid_jwt, invalid_jwt_expected_payload
+def test_health_call_with_wrong_authorization_type(
+        route, client, valid_jwt,
+        authorization_errors_expected_payload
+):
+    response = client.post(
+        route, headers=headers(valid_jwt, auth_type='wrong_type')
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_authorization_type'
+    )
+
+
+def test_health_call_with_wrong_jwt_structure(
+        route, client, wrong_jwt_structure,
+        authorization_errors_expected_payload
+):
+    response = client.post(route, headers=headers(wrong_jwt_structure))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_structure'
+    )
+
+
+def test_health_call_with_jwt_encoded_by_wrong_key(
+        route, client, invalid_jwt,
+        authorization_errors_expected_payload
 ):
     response = client.post(route, headers=headers(invalid_jwt))
 
     assert response.status_code == HTTPStatus.OK
-    assert response.json == invalid_jwt_expected_payload
+    assert response.json == authorization_errors_expected_payload(
+        'jwt_encoded_by_wrong_key'
+    )
+
+
+def test_health_call_with_wrong_jwt_payload_structure(
+        route, client, wrong_payload_structure_jwt,
+        authorization_errors_expected_payload
+):
+    response = client.post(route,
+                           headers=headers(wrong_payload_structure_jwt))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'wrong_jwt_payload_structure'
+    )
+
+
+def test_health_call_with_missed_secret_key(
+        route, client, valid_jwt,
+        authorization_errors_expected_payload
+):
+    right_secret_key = client.application.secret_key
+    client.application.secret_key = None
+    response = client.post(route, headers=headers(valid_jwt))
+    client.application.secret_key = right_secret_key
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == authorization_errors_expected_payload(
+        'missed_secret_key'
+    )
+
+
+def test_health_call_with_invalid_creds_failure(
+        route, client, valid_jwt,
+        authorization_errors_expected_payload
+):
+    with patch('api.utils.service_account.'
+               'Credentials.from_service_account_info',
+               side_effect=ValueError("Wrong structure")):
+        response = client.post(route, headers=headers(valid_jwt))
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json == authorization_errors_expected_payload(
+            'invalid_creds_failure'
+        )
 
 
 def test_health_call_with_unauthorized_creds_failure(
@@ -49,18 +124,6 @@ def test_health_call_with_unauthorized_creds_failure(
         response = client.post(route, headers=headers(valid_jwt))
 
         assert response.json == unauthorized_creds_expected_payload
-
-
-def test_health_call_with_invalid_creds_failure(
-        route, client, valid_jwt, invalid_creds_expected_payload
-):
-    with patch('api.utils.service_account.'
-               'Credentials.from_service_account_info',
-               side_effect=ValueError("Wrong structure")):
-        response = client.post(route, headers=headers(valid_jwt))
-
-        assert response.status_code == HTTPStatus.OK
-        assert response.json == invalid_creds_expected_payload
 
 
 def test_health_call_success(route, client, valid_jwt, chronicle_response_ok):

--- a/tests/unit/api/utils.py
+++ b/tests/unit/api/utils.py
@@ -1,2 +1,2 @@
-def headers(jwt):
-    return {'Authorization': f'Bearer {jwt}'}
+def headers(jwt, auth_type='Bearer'):
+    return {'Authorization': f'{auth_type} {jwt}'}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -140,6 +140,7 @@ def valid_jwt(secret_key):
         "project_id": "<PROJECT_ID>",
         "private_key_id": "<PRIVATE_KEY_ID>",
         "private_key": "<PRIVATE_KEY>",
+        "client_email": "<CLIENT_EMAIL>",
         "client_id": "<CLIENT_ID>",
         "auth_uri": "<AUTH_URI>",
         "token_uri": "<TOKEN_URI>",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,11 @@ from authlib.jose import jwt
 from pytest import fixture
 
 from api.errors import (
-    PERMISSION_DENIED, INVALID_ARGUMENT, TOO_MANY_REQUESTS, UNKNOWN
+    PERMISSION_DENIED,
+    INVALID_ARGUMENT,
+    TOO_MANY_REQUESTS,
+    UNKNOWN,
+    AUTH_ERROR
 )
 from app import app
 
@@ -137,7 +141,8 @@ def invalid_jwt(valid_jwt, secret_key):
 
     def jwt_encode(d: dict) -> str:
         from authlib.common.encoding import json_dumps, urlsafe_b64encode
-        return urlsafe_b64encode(json_dumps(d).encode('ascii')).decode('ascii')
+        return urlsafe_b64encode(json_dumps(d).encode('ascii')).decode(
+            'ascii')
 
     payload = jwt_decode(payload)
 
@@ -165,8 +170,25 @@ def invalid_jwt_expected_payload(route):
         route,
         {
             'errors': [
-                {'code': PERMISSION_DENIED,
-                 'message': 'Invalid Authorization Bearer JWT.',
+                {'code': AUTH_ERROR,
+                 'message': 'Authorization failed: Failed to decode JWT '
+                            'with provided key',
+                 'type': 'fatal'}
+            ],
+            'data': {}
+        }
+    )
+
+
+@fixture(scope='module')
+def authorization_is_missing_expected_payload(route):
+    return expected_payload(
+        route,
+        {
+            'errors': [
+                {'code': AUTH_ERROR,
+                 'message': 'Authorization failed: '
+                            'Authorization header is missing',
                  'type': 'fatal'}
             ],
             'data': {}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -191,17 +191,7 @@ def expected_payload(r, body):
 
 @fixture(scope='module')
 def authorization_errors_expected_payload(route):
-    def _make_payload_message(test_name):
-        messages = {
-            'authorization_header_failure': 'Authorization header is missing',
-            'wrong_authorization_type': 'Wrong authorization type',
-            'wrong_jwt_structure': 'Wrong JWT structure',
-            'jwt_encoded_by_wrong_key':
-                'Failed to decode JWT with provided key',
-            'wrong_jwt_payload_structure': 'Wrong JWT payload structure',
-            'missed_secret_key': '<SECRET_KEY> is missing',
-            'invalid_creds_failure': 'Wrong structure'
-        }
+    def _make_payload_message(message):
         return expected_payload(
             route,
             {
@@ -210,7 +200,7 @@ def authorization_errors_expected_payload(route):
                     {
                         "code": AUTH_ERROR,
                         "message": f'Authorization failed: '
-                                   f'{messages[test_name]}',
+                                   f'{message}',
                         "type": "fatal"
                     }
                 ]


### PR DESCRIPTION
errors.py - InwalidJWTError replaced to Authorizationerror;
utils.py - add get_auth_token(), get_jwt() changed;
conftest.py - add authorization_is_missing_expected_payload(),
    invalid_jwt_expected_payload() changed
test_health.py and test_enrich.py - little changes in test…without_jwt_failure.